### PR TITLE
Include return type with invoke call for methods with return types

### DIFF
--- a/src/SigSpec.CodeGeneration.CSharp/Templates/Hub.liquid
+++ b/src/SigSpec.CodeGeneration.CSharp/Templates/Hub.liquid
@@ -65,7 +65,7 @@
 {%     elsif operation.HasReturnType -%}
         public async Task<{{ operation.ReturnType.Type }}> {{ operation.Name }}({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.Name }}, {% endfor %}CancellationToken token = default(CancellationToken))
         {
-            return await _connection.InvokeAsync("{{ operation.Name }}"{% for parameter in operation.Parameters %}, {{ parameter.Name }}{% endfor %}, token);
+            return await _connection.InvokeAsync<{{ operation.ReturnType.Type }}>("{{ operation.Name }}"{% for parameter in operation.Parameters %}, {{ parameter.Name }}{% endfor %}, token);
         }
 
 {%     else -%}


### PR DESCRIPTION
Currently if a method has a return type, the InvokeAsync method does not specify the return type, which ends up generating invalid code.

This adds the return type to the InvokeAsync call.