### PR TITLE
Update and remove no longer needed nuget packages

### DIFF
--- a/src/SigSpec.AspNetCore/SigSpec.AspNetCore.csproj
+++ b/src/SigSpec.AspNetCore/SigSpec.AspNetCore.csproj
@@ -20,9 +20,9 @@
     <EmbeddedResource Include="SigSpecUi\index.html" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.4" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.38" />
+	<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.23" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />

--- a/src/SigSpec.AspNetCore/SigSpec.AspNetCore.csproj
+++ b/src/SigSpec.AspNetCore/SigSpec.AspNetCore.csproj
@@ -20,11 +20,6 @@
     <EmbeddedResource Include="SigSpecUi\index.html" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.38" />
-	<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.23" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/SigSpec.CodeGeneration.CSharp.Tests/SigSpec.CodeGeneration.CSharp.Tests.csproj
+++ b/src/SigSpec.CodeGeneration.CSharp.Tests/SigSpec.CodeGeneration.CSharp.Tests.csproj
@@ -8,7 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.23" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="xunit" Version="2.5.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">

--- a/src/SigSpec.CodeGeneration.CSharp.Tests/SigSpec.CodeGeneration.CSharp.Tests.csproj
+++ b/src/SigSpec.CodeGeneration.CSharp.Tests/SigSpec.CodeGeneration.CSharp.Tests.csproj
@@ -8,13 +8,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.23" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="xunit" Version="2.5.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SigSpec.CodeGeneration.CSharp/SigSpec.CodeGeneration.CSharp.csproj
+++ b/src/SigSpec.CodeGeneration.CSharp/SigSpec.CodeGeneration.CSharp.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="njsonschema.codegeneration" Version="10.8.0" />
-    <PackageReference Include="njsonschema.codegeneration.csharp" Version="10.8.0" />
+    <PackageReference Include="njsonschema.codegeneration" Version="10.9.0" />
+    <PackageReference Include="njsonschema.codegeneration.csharp" Version="10.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SigSpec.CodeGeneration.TypeScript/SigSpec.CodeGeneration.TypeScript.csproj
+++ b/src/SigSpec.CodeGeneration.TypeScript/SigSpec.CodeGeneration.TypeScript.csproj
@@ -22,8 +22,8 @@
     <EmbeddedResource Include="Templates\Hub.liquid" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.8.0" />
-    <PackageReference Include="NJsonSchema.CodeGeneration.TypeScript" Version="10.8.0" />
+    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.9.0" />
+    <PackageReference Include="NJsonSchema.CodeGeneration.TypeScript" Version="10.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />

--- a/src/SigSpec.CodeGeneration/SigSpec.CodeGeneration.csproj
+++ b/src/SigSpec.CodeGeneration/SigSpec.CodeGeneration.csproj
@@ -14,7 +14,7 @@
     <PackageTags>SignalR Specification CodeGeneration</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.8.0" />
+    <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />

--- a/src/SigSpec.Core/SigSpec.Core.csproj
+++ b/src/SigSpec.Core/SigSpec.Core.csproj
@@ -15,7 +15,7 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="NJsonSchema" Version="10.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Update a bunch of nuget packages.
- Remove `SigSpec.AspNetCore` nuget packages that are no longer needed due to NET6 move.