### PR TITLE
Ignore launch settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _ReSharper*/
 *.DotSettings.user
 # Jetbrains Rider
 .idea/
+src/SigSpec.Core/Properties/launchSettings.json


### PR DESCRIPTION
`launchSettings.json` keeps appearing as a change to my local SigSpec so add it to the .gitignore.