### PR TITLE
Do nullable parameters properly in TS and C#

### DIFF
--- a/src/SigSpec.CodeGeneration.CSharp.Tests/GeneratorTests.cs
+++ b/src/SigSpec.CodeGeneration.CSharp.Tests/GeneratorTests.cs
@@ -35,10 +35,12 @@ namespace SigSpec.CodeGeneration.CSharp.Tests
 		[InlineData(typeof(HubWithGuid), "System.Guid")]
 		[InlineData(typeof(HubWithGuidOptional), "System.Guid?")]
 		[InlineData(typeof(HubWithStruct), "TestStruct")]
-		[InlineData(typeof(HubWithNullableStruct), "TestStruct?")]
-		[InlineData(typeof(HubWithStructOptional), "TestStruct?")]
+		[InlineData(typeof(HubWithNullableStruct), "TestStruct")]
+		[InlineData(typeof(HubWithStructOptional), "TestStruct")]
 		[InlineData(typeof(HubWithObject), "TestClass")]
 		[InlineData(typeof(HubWithObjectOptional), "TestClass")]
+		[InlineData(typeof(HubWithBool), "bool")]
+		[InlineData(typeof(HubWithBoolOptional), "bool?")]
 		public async Task GenerateHubClient_GeneratesCorrectly(Type hub, string parameter)
 		{
 			var file = await GenerateHubClient(hub);

--- a/src/SigSpec.CodeGeneration.CSharp.Tests/NullableGeneratorTests.cs
+++ b/src/SigSpec.CodeGeneration.CSharp.Tests/NullableGeneratorTests.cs
@@ -39,6 +39,8 @@ public class NullableGeneratorTests
 	[InlineData(typeof(HubWithStructOptional), "TestStruct?")]
 	[InlineData(typeof(HubWithObject), "TestClass")]
 	[InlineData(typeof(HubWithObjectOptional), "TestClass?")]
+	[InlineData(typeof(HubWithBool), "bool")]
+	[InlineData(typeof(HubWithBoolOptional), "bool?")]
 	public async Task GenerateHubClient_WithNullablesAllowed_GeneratesCorrectly(Type hub, string parameter)
 	{
 		var file = await GenerateHubClient(hub);

--- a/src/SigSpec.CodeGeneration.TypeScript.Tests/NullableGeneratorTests.cs
+++ b/src/SigSpec.CodeGeneration.TypeScript.Tests/NullableGeneratorTests.cs
@@ -1,0 +1,59 @@
+﻿using NJsonSchema.CodeGeneration.TypeScript;
+using SigSpec.Core;
+using Xunit;
+
+namespace SigSpec.CodeGeneration.TypeScript.Tests;
+
+public class NullableGeneratorTests
+{
+	private readonly SigSpecGeneratorSettings _settings = new SigSpecGeneratorSettings();
+	private readonly SigSpecGenerator _generator;
+
+	private readonly SigSpecToTypeScriptGeneratorSettings _codeGeneratorSettings = new()
+	{
+		TypeScriptGeneratorSettings =
+		{
+			TypeStyle = TypeScriptTypeStyle.Class,
+			NullValue = TypeScriptNullValue.Null,
+			MarkOptionalProperties = false,
+			ConvertConstructorInterfaceData = true
+		}
+	};
+
+	private readonly SigSpecToTypeScriptGenerator _codeGenerator;
+
+	public NullableGeneratorTests()
+	{
+		_generator = new SigSpecGenerator(_settings);
+		_codeGenerator = new SigSpecToTypeScriptGenerator(_codeGeneratorSettings);
+	}
+
+	[Theory]
+	[InlineData(typeof(HubWithString), "string")]
+	[InlineData(typeof(HubWithStringOptional), "string | null")]
+	[InlineData(typeof(HubWithInt), "number")]
+	[InlineData(typeof(HubWithIntOptional), "number | null")]
+	[InlineData(typeof(HubWithGuid), "string")]
+	[InlineData(typeof(HubWithGuidOptional), "string | null")]
+	[InlineData(typeof(HubWithStruct), "TestStruct")]
+	[InlineData(typeof(HubWithNullableStruct), "TestStruct | null")]
+	[InlineData(typeof(HubWithStructOptional), "TestStruct | null")]
+	[InlineData(typeof(HubWithObject), "TestClass")]
+	[InlineData(typeof(HubWithObjectOptional), "TestClass | null")]
+	[InlineData(typeof(HubWithBool), "boolean")]
+	[InlineData(typeof(HubWithBoolOptional), "boolean | null")]
+	public async Task GenerateHubClient_WithNullablesAllowed_GeneratesCorrectly(Type hub, string parameter)
+	{
+		var file = await GenerateHubClient(hub);
+		Assert.Contains($"method(message: {parameter})", file);
+	}
+
+	private async Task<string> GenerateHubClient(Type type)
+	{
+		var document = await _generator.GenerateForHubsAsync(new Dictionary<string, Type>
+		{
+			{ "Hub", type }
+		});
+		return _codeGenerator.GenerateFile(document);
+	}
+}

--- a/src/SigSpec.CodeGeneration.TypeScript.Tests/SigSpec.CodeGeneration.TypeScript.Tests.csproj
+++ b/src/SigSpec.CodeGeneration.TypeScript.Tests/SigSpec.CodeGeneration.TypeScript.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\SigSpec.CodeGeneration.TypeScript\SigSpec.CodeGeneration.TypeScript.csproj" />
+		<ProjectReference Include="..\SigSpec.Core\SigSpec.Core.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/SigSpec.CodeGeneration.TypeScript.Tests/TestHubs.cs
+++ b/src/SigSpec.CodeGeneration.TypeScript.Tests/TestHubs.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
+﻿using Microsoft.AspNetCore.SignalR;
 
-namespace SigSpec.CodeGeneration.CSharp.Tests;
+namespace SigSpec.CodeGeneration.TypeScript.Tests;
 
 public class HubWithString : Hub<IClient>
 {

--- a/src/SigSpec.CodeGeneration/Models/ParameterModel.cs
+++ b/src/SigSpec.CodeGeneration/Models/ParameterModel.cs
@@ -18,16 +18,7 @@ namespace SigSpec.CodeGeneration.Models
             }
             else
             {
-                // if parameter is a value type and nullable but does not have "?" we need to add it always
-                if (parameter.IsValueType && parameter.Optional)
-                {
-                    GenerateOptional = false;
-                    Type += "?";
-                }
-                else
-                {
-                    GenerateOptional = parameter.Optional;
-                }
+                GenerateOptional = parameter.Optional;
             }
         }
 

--- a/src/SigSpec.sln
+++ b/src/SigSpec.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34031.279
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelloSignalR", "HelloSignalR\HelloSignalR.csproj", "{F953B5DD-29F5-4C92-A057-B693767E3E74}"
 EndProject
@@ -20,9 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{EC91FE8E
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SigSpec.CodeGeneration.CSharp", "SigSpec.CodeGeneration.CSharp\SigSpec.CodeGeneration.CSharp.csproj", "{FF02610E-C750-46DC-B902-D6ED2D48BF5A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SigSpec.CodeGeneration.CSharp", "SigSpec.CodeGeneration.CSharp\SigSpec.CodeGeneration.CSharp.csproj", "{FF02610E-C750-46DC-B902-D6ED2D48BF5A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SigSpec.CodeGeneration.CSharp.Tests", "SigSpec.CodeGeneration.CSharp.Tests\SigSpec.CodeGeneration.CSharp.Tests.csproj", "{B86510C2-6F78-440D-9144-90648698DA58}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SigSpec.CodeGeneration.CSharp.Tests", "SigSpec.CodeGeneration.CSharp.Tests\SigSpec.CodeGeneration.CSharp.Tests.csproj", "{B86510C2-6F78-440D-9144-90648698DA58}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SigSpec.CodeGeneration.TypeScript.Tests", "SigSpec.CodeGeneration.TypeScript.Tests\SigSpec.CodeGeneration.TypeScript.Tests.csproj", "{982E814E-0615-4C72-8BCD-D2D7A673B762}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,6 +64,10 @@ Global
 		{B86510C2-6F78-440D-9144-90648698DA58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B86510C2-6F78-440D-9144-90648698DA58}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B86510C2-6F78-440D-9144-90648698DA58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{982E814E-0615-4C72-8BCD-D2D7A673B762}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{982E814E-0615-4C72-8BCD-D2D7A673B762}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{982E814E-0615-4C72-8BCD-D2D7A673B762}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{982E814E-0615-4C72-8BCD-D2D7A673B762}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
A previous change to how nullable parameters were generated was incorrect as it would add a '?' to TypeScript in the `ParameterModel` class files instead of relying on the liquid template. 

This PR adds test for nullable parameters and fixes the broken tests which assumed nullables were being generated when they weren't.