### PR TITLE
Fix dependencies out of order and not reload

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+indent_style = space

--- a/src/SigSpec.CodeGeneration.TypeScript/SigSpecToTypeScriptGenerator.cs
+++ b/src/SigSpec.CodeGeneration.TypeScript/SigSpecToTypeScriptGenerator.cs
@@ -8,51 +8,51 @@ using System.Linq;
 
 namespace SigSpec.CodeGeneration.TypeScript
 {
-    public class SigSpecToTypeScriptGenerator
-    {
-        private readonly SigSpecToTypeScriptGeneratorSettings _settings;
+	public class SigSpecToTypeScriptGenerator
+	{
+		private readonly SigSpecToTypeScriptGeneratorSettings _settings;
 
-        public SigSpecToTypeScriptGenerator(SigSpecToTypeScriptGeneratorSettings settings)
-        {
-            _settings = settings;
-        }
+		public SigSpecToTypeScriptGenerator(SigSpecToTypeScriptGeneratorSettings settings)
+		{
+			_settings = settings;
+		}
 
-        public IEnumerable<CodeArtifact> GenerateArtifacts(SigSpecDocument document)
-        {
-            var resolver = new TypeScriptTypeResolver(_settings.TypeScriptGeneratorSettings);
-            resolver.RegisterSchemaDefinitions(document.Definitions);
+		public IEnumerable<CodeArtifact> GenerateArtifacts(SigSpecDocument document)
+		{
+			var resolver = new TypeScriptTypeResolver(_settings.TypeScriptGeneratorSettings);
+			resolver.RegisterSchemaDefinitions(document.Definitions);
 
-            var artifacts = new List<CodeArtifact>();
-            foreach (var hub in document.Hubs)
-            {
-                var hubModel = new HubModel(hub.Key, hub.Value, resolver);
-                var template = _settings.TypeScriptGeneratorSettings.TemplateFactory.CreateTemplate("TypeScript", "Hub", hubModel);
-                artifacts.Add(new CodeArtifact(hubModel.Name, CodeArtifactType.Class, CodeArtifactLanguage.TypeScript, CodeArtifactCategory.Client, template.Render()));
-            }
+			var artifacts = new List<CodeArtifact>();
+			foreach (var hub in document.Hubs)
+			{
+				var hubModel = new HubModel(hub.Key, hub.Value, resolver);
+				var template = _settings.TypeScriptGeneratorSettings.TemplateFactory.CreateTemplate("TypeScript", "Hub", hubModel);
+				artifacts.Add(new CodeArtifact(hubModel.Name, CodeArtifactType.Class, CodeArtifactLanguage.TypeScript, CodeArtifactCategory.Client, template.Render()));
+			}
 
-            if (_settings.GenerateDtoTypes)
-            {
-                var generator = new TypeScriptGenerator(document, _settings.TypeScriptGeneratorSettings, resolver);
-                var types = generator.GenerateTypes();
+			if (_settings.GenerateDtoTypes)
+			{
+				var generator = new TypeScriptGenerator(document, _settings.TypeScriptGeneratorSettings, resolver);
+				var types = generator.GenerateTypes();
 
-                return artifacts.Concat(types);
-            }
-            else
-            {
-                var generator = new TypeScriptGenerator(document, _settings.TypeScriptGeneratorSettings, resolver);
-                var extensionCode = new TypeScriptExtensionCode(_settings.TypeScriptGeneratorSettings.ExtensionCode, _settings.TypeScriptGeneratorSettings.ExtendedClasses);
-                return artifacts.Concat(generator.GenerateTypes(extensionCode));
-            }
-        }
+				return artifacts.Concat(types);
+			}
+			else
+			{
+				var generator = new TypeScriptGenerator(document, _settings.TypeScriptGeneratorSettings, resolver);
+				var extensionCode = new TypeScriptExtensionCode(_settings.TypeScriptGeneratorSettings.ExtensionCode, _settings.TypeScriptGeneratorSettings.ExtendedClasses);
+				return artifacts.Concat(generator.GenerateTypes(extensionCode));
+			}
+		}
 
-        public string GenerateFile(SigSpecDocument document)
-        {
-            var artifacts = GenerateArtifacts(document);
+		public string GenerateFile(SigSpecDocument document)
+		{
+			var artifacts = GenerateArtifacts(document);
 
-            var fileModel = new FileModel(artifacts.Select(a => a.Code));
-            var fileTemplate = _settings.TypeScriptGeneratorSettings.TemplateFactory.CreateTemplate("TypeScript", "HubFile", fileModel);
+			var fileModel = new FileModel(artifacts.OrderByBaseDependency().Select(a => a.Code));
+			var fileTemplate = _settings.TypeScriptGeneratorSettings.TemplateFactory.CreateTemplate("TypeScript", "HubFile", fileModel);
 
-            return fileTemplate.Render();
-        }
-    }
+			return fileTemplate.Render();
+		}
+	}
 }

--- a/src/SigSpec.CodeGeneration.TypeScript/SigSpecToTypeScriptGenerator.cs
+++ b/src/SigSpec.CodeGeneration.TypeScript/SigSpecToTypeScriptGenerator.cs
@@ -8,51 +8,51 @@ using System.Linq;
 
 namespace SigSpec.CodeGeneration.TypeScript
 {
-	public class SigSpecToTypeScriptGenerator
-	{
-		private readonly SigSpecToTypeScriptGeneratorSettings _settings;
+    public class SigSpecToTypeScriptGenerator
+    {
+        private readonly SigSpecToTypeScriptGeneratorSettings _settings;
 
-		public SigSpecToTypeScriptGenerator(SigSpecToTypeScriptGeneratorSettings settings)
-		{
-			_settings = settings;
-		}
+        public SigSpecToTypeScriptGenerator(SigSpecToTypeScriptGeneratorSettings settings)
+        {
+            _settings = settings;
+        }
 
-		public IEnumerable<CodeArtifact> GenerateArtifacts(SigSpecDocument document)
-		{
-			var resolver = new TypeScriptTypeResolver(_settings.TypeScriptGeneratorSettings);
-			resolver.RegisterSchemaDefinitions(document.Definitions);
+        public IEnumerable<CodeArtifact> GenerateArtifacts(SigSpecDocument document)
+        {
+            var resolver = new TypeScriptTypeResolver(_settings.TypeScriptGeneratorSettings);
+            resolver.RegisterSchemaDefinitions(document.Definitions);
 
-			var artifacts = new List<CodeArtifact>();
-			foreach (var hub in document.Hubs)
-			{
-				var hubModel = new HubModel(hub.Key, hub.Value, resolver);
-				var template = _settings.TypeScriptGeneratorSettings.TemplateFactory.CreateTemplate("TypeScript", "Hub", hubModel);
-				artifacts.Add(new CodeArtifact(hubModel.Name, CodeArtifactType.Class, CodeArtifactLanguage.TypeScript, CodeArtifactCategory.Client, template.Render()));
-			}
+            var artifacts = new List<CodeArtifact>();
+            foreach (var hub in document.Hubs)
+            {
+                var hubModel = new HubModel(hub.Key, hub.Value, resolver);
+                var template = _settings.TypeScriptGeneratorSettings.TemplateFactory.CreateTemplate("TypeScript", "Hub", hubModel);
+                artifacts.Add(new CodeArtifact(hubModel.Name, CodeArtifactType.Class, CodeArtifactLanguage.TypeScript, CodeArtifactCategory.Client, template.Render()));
+            }
 
-			if (_settings.GenerateDtoTypes)
-			{
-				var generator = new TypeScriptGenerator(document, _settings.TypeScriptGeneratorSettings, resolver);
-				var types = generator.GenerateTypes();
+            if (_settings.GenerateDtoTypes)
+            {
+                var generator = new TypeScriptGenerator(document, _settings.TypeScriptGeneratorSettings, resolver);
+                var types = generator.GenerateTypes();
 
-				return artifacts.Concat(types);
-			}
-			else
-			{
-				var generator = new TypeScriptGenerator(document, _settings.TypeScriptGeneratorSettings, resolver);
-				var extensionCode = new TypeScriptExtensionCode(_settings.TypeScriptGeneratorSettings.ExtensionCode, _settings.TypeScriptGeneratorSettings.ExtendedClasses);
-				return artifacts.Concat(generator.GenerateTypes(extensionCode));
-			}
-		}
+                return artifacts.Concat(types);
+            }
+            else
+            {
+                var generator = new TypeScriptGenerator(document, _settings.TypeScriptGeneratorSettings, resolver);
+                var extensionCode = new TypeScriptExtensionCode(_settings.TypeScriptGeneratorSettings.ExtensionCode, _settings.TypeScriptGeneratorSettings.ExtendedClasses);
+                return artifacts.Concat(generator.GenerateTypes(extensionCode));
+            }
+        }
 
-		public string GenerateFile(SigSpecDocument document)
-		{
-			var artifacts = GenerateArtifacts(document);
+        public string GenerateFile(SigSpecDocument document)
+        {
+            var artifacts = GenerateArtifacts(document);
 
-			var fileModel = new FileModel(artifacts.OrderByBaseDependency().Select(a => a.Code));
-			var fileTemplate = _settings.TypeScriptGeneratorSettings.TemplateFactory.CreateTemplate("TypeScript", "HubFile", fileModel);
+            var fileModel = new FileModel(artifacts.OrderByBaseDependency().Select(a => a.Code));
+            var fileTemplate = _settings.TypeScriptGeneratorSettings.TemplateFactory.CreateTemplate("TypeScript", "HubFile", fileModel);
 
-			return fileTemplate.Render();
-		}
-	}
+            return fileTemplate.Render();
+        }
+    }
 }

--- a/src/SigSpec.Core/SigSpecDocument.cs
+++ b/src/SigSpec.Core/SigSpecDocument.cs
@@ -8,33 +8,33 @@ using System.Collections.Generic;
 
 namespace SigSpec.Core
 {
-    [JsonConverter(typeof(JsonReferenceConverter))]
-    public class SigSpecDocument
-    {
-        private static Lazy<JsonSerializerSettings> _serializerSettings = new Lazy<JsonSerializerSettings>(() => new JsonSerializerSettings
-        {
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
-            Converters = new List<JsonConverter> { new StringEnumConverter() }
-        });
+	[JsonConverter(typeof(JsonReferenceConverter))]
+	public class SigSpecDocument
+	{
+		private static Lazy<JsonSerializerSettings> _serializerSettings = new Lazy<JsonSerializerSettings>(() => new JsonSerializerSettings
+		{
+			ContractResolver = new UnsharedCamelCasePropertyNamesContractResolver(),
+			Converters = new List<JsonConverter> { new StringEnumConverter() }
+		});
 
-        /// <summary>Gets or sets the SigSpec specification version being used.</summary>
-        [JsonProperty(PropertyName = "sigspec", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public string SigSpec { get; set; } = "1.0.0";
+		/// <summary>Gets or sets the SigSpec specification version being used.</summary>
+		[JsonProperty(PropertyName = "sigspec", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+		public string SigSpec { get; set; } = "1.0.0";
 
-        /// <summary>Gets or sets the metadata about the API.</summary>
-        [JsonProperty(PropertyName = "info", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public SigSpecInfo Info { get; set; } = new SigSpecInfo();
+		/// <summary>Gets or sets the metadata about the API.</summary>
+		[JsonProperty(PropertyName = "info", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+		public SigSpecInfo Info { get; set; } = new SigSpecInfo();
 
-        /// <summary>Gets the exposed SignalR hubs.</summary>
-        [JsonProperty("hubs")]
-        public IDictionary<string, SigSpecHub> Hubs { get; } = new Dictionary<string, SigSpecHub>();
+		/// <summary>Gets the exposed SignalR hubs.</summary>
+		[JsonProperty("hubs")]
+		public IDictionary<string, SigSpecHub> Hubs { get; } = new Dictionary<string, SigSpecHub>();
 
-        [JsonProperty("definitions")]
-        public IDictionary<string, JsonSchema> Definitions { get; } = new Dictionary<string, JsonSchema>();
+		[JsonProperty("definitions")]
+		public IDictionary<string, JsonSchema> Definitions { get; } = new Dictionary<string, JsonSchema>();
 
-        public string ToJson()
-        {
-            return JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings.Value);
-        }
-    }
+		public string ToJson()
+		{
+			return JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings.Value);
+		}
+	}
 }

--- a/src/SigSpec.Core/SigSpecDocument.cs
+++ b/src/SigSpec.Core/SigSpecDocument.cs
@@ -8,33 +8,33 @@ using System.Collections.Generic;
 
 namespace SigSpec.Core
 {
-	[JsonConverter(typeof(JsonReferenceConverter))]
-	public class SigSpecDocument
-	{
-		private static Lazy<JsonSerializerSettings> _serializerSettings = new Lazy<JsonSerializerSettings>(() => new JsonSerializerSettings
-		{
-			ContractResolver = new UnsharedCamelCasePropertyNamesContractResolver(),
-			Converters = new List<JsonConverter> { new StringEnumConverter() }
-		});
+    [JsonConverter(typeof(JsonReferenceConverter))]
+    public class SigSpecDocument
+    {
+        private static Lazy<JsonSerializerSettings> _serializerSettings = new Lazy<JsonSerializerSettings>(() => new JsonSerializerSettings
+        {
+            ContractResolver = new UnsharedCamelCasePropertyNamesContractResolver(),
+            Converters = new List<JsonConverter> { new StringEnumConverter() }
+        });
 
-		/// <summary>Gets or sets the SigSpec specification version being used.</summary>
-		[JsonProperty(PropertyName = "sigspec", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-		public string SigSpec { get; set; } = "1.0.0";
+        /// <summary>Gets or sets the SigSpec specification version being used.</summary>
+        [JsonProperty(PropertyName = "sigspec", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public string SigSpec { get; set; } = "1.0.0";
 
-		/// <summary>Gets or sets the metadata about the API.</summary>
-		[JsonProperty(PropertyName = "info", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-		public SigSpecInfo Info { get; set; } = new SigSpecInfo();
+        /// <summary>Gets or sets the metadata about the API.</summary>
+        [JsonProperty(PropertyName = "info", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public SigSpecInfo Info { get; set; } = new SigSpecInfo();
 
-		/// <summary>Gets the exposed SignalR hubs.</summary>
-		[JsonProperty("hubs")]
-		public IDictionary<string, SigSpecHub> Hubs { get; } = new Dictionary<string, SigSpecHub>();
+        /// <summary>Gets the exposed SignalR hubs.</summary>
+        [JsonProperty("hubs")]
+        public IDictionary<string, SigSpecHub> Hubs { get; } = new Dictionary<string, SigSpecHub>();
 
-		[JsonProperty("definitions")]
-		public IDictionary<string, JsonSchema> Definitions { get; } = new Dictionary<string, JsonSchema>();
+        [JsonProperty("definitions")]
+        public IDictionary<string, JsonSchema> Definitions { get; } = new Dictionary<string, JsonSchema>();
 
-		public string ToJson()
-		{
-			return JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings.Value);
-		}
-	}
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings.Value);
+        }
+    }
 }

--- a/src/SigSpec.Core/SigSpecGeneratorSettings.cs
+++ b/src/SigSpec.Core/SigSpecGeneratorSettings.cs
@@ -3,14 +3,14 @@ using NJsonSchema.Generation;
 
 namespace SigSpec.Core
 {
-	public class SigSpecGeneratorSettings : JsonSchemaGeneratorSettings
-	{
-		public SigSpecGeneratorSettings()
-		{
-			SerializerSettings = new JsonSerializerSettings()
-			{
-				ContractResolver = new UnsharedCamelCasePropertyNamesContractResolver()
-			};
-		}
-	}
+    public class SigSpecGeneratorSettings : JsonSchemaGeneratorSettings
+    {
+        public SigSpecGeneratorSettings()
+        {
+            SerializerSettings = new JsonSerializerSettings()
+            {
+                ContractResolver = new UnsharedCamelCasePropertyNamesContractResolver()
+            };
+        }
+    }
 }

--- a/src/SigSpec.Core/SigSpecGeneratorSettings.cs
+++ b/src/SigSpec.Core/SigSpecGeneratorSettings.cs
@@ -1,17 +1,16 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using NJsonSchema.Generation;
 
 namespace SigSpec.Core
 {
-    public class SigSpecGeneratorSettings : JsonSchemaGeneratorSettings
-    {
-        public SigSpecGeneratorSettings()
-        {
-            SerializerSettings = new JsonSerializerSettings()
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            };
-        }
-    }
+	public class SigSpecGeneratorSettings : JsonSchemaGeneratorSettings
+	{
+		public SigSpecGeneratorSettings()
+		{
+			SerializerSettings = new JsonSerializerSettings()
+			{
+				ContractResolver = new UnsharedCamelCasePropertyNamesContractResolver()
+			};
+		}
+	}
 }

--- a/src/SigSpec.Core/UnsharedCamelCasePropertyNamesContractResolver.cs
+++ b/src/SigSpec.Core/UnsharedCamelCasePropertyNamesContractResolver.cs
@@ -9,15 +9,15 @@ namespace SigSpec.Core;
 /// <seealso cref="CamelCasePropertyNamesContractResolver" />
 public class UnsharedCamelCasePropertyNamesContractResolver : DefaultContractResolver
 {
-	/// <summary>
-	/// Initializes a new instance of the <see cref="CamelCasePropertyNamesContractResolver"/> class.
-	/// </summary>
-	public UnsharedCamelCasePropertyNamesContractResolver()
-	{
-		NamingStrategy = new CamelCaseNamingStrategy
-		{
-			ProcessDictionaryKeys = true,
-			OverrideSpecifiedNames = true
-		};
-	}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CamelCasePropertyNamesContractResolver"/> class.
+    /// </summary>
+    public UnsharedCamelCasePropertyNamesContractResolver()
+    {
+        NamingStrategy = new CamelCaseNamingStrategy
+        {
+            ProcessDictionaryKeys = true,
+            OverrideSpecifiedNames = true
+        };
+    }
 }

--- a/src/SigSpec.Core/UnsharedCamelCasePropertyNamesContractResolver.cs
+++ b/src/SigSpec.Core/UnsharedCamelCasePropertyNamesContractResolver.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json.Serialization;
+
+namespace SigSpec.Core;
+
+/// <summary>
+/// CamelCase property names contract resolver that doesn't share contract cache with other instances.
+/// Makes types update after a hot reload.
+/// </summary>
+/// <seealso cref="CamelCasePropertyNamesContractResolver" />
+public class UnsharedCamelCasePropertyNamesContractResolver : DefaultContractResolver
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="CamelCasePropertyNamesContractResolver"/> class.
+	/// </summary>
+	public UnsharedCamelCasePropertyNamesContractResolver()
+	{
+		NamingStrategy = new CamelCaseNamingStrategy
+		{
+			ProcessDictionaryKeys = true,
+			OverrideSpecifiedNames = true
+		};
+	}
+}


### PR DESCRIPTION
Don't use CamelCasePropertyNamesContractResolver as it statically caches types, so it won't see the changes from a hot reload.

Sort classes using OrderByBaseDependency so they end up in order (BaseClass before ChildClass)