### PR TITLE
TS doesn't like unused params, in the case where we dont call methods…

### DIFF
--- a/src/SigSpec.CodeGeneration.TypeScript/Templates/Hub.liquid
+++ b/src/SigSpec.CodeGeneration.TypeScript/Templates/Hub.liquid
@@ -1,4 +1,5 @@
 ﻿export class {{ Name }}Hub {
+	// @ts-ignore
     constructor(private connection: HubConnection, private onBeforeSend?: (methodName: string, ...args: any[]) => void) {
     }
 {% for operation in Operations -%}


### PR DESCRIPTION
Added // @ts-ignore to stop TS error with unused onBeforeSend 