### PR TITLE
Ignore static methods

### DIFF
--- a/src/SigSpec.CodeGeneration.CSharp.Tests/GeneratorTests.cs
+++ b/src/SigSpec.CodeGeneration.CSharp.Tests/GeneratorTests.cs
@@ -47,6 +47,13 @@ namespace SigSpec.CodeGeneration.CSharp.Tests
 			Assert.Contains($"public Task Method({parameter} message, CancellationToken token = default(CancellationToken));", file);
 		}
 
+		[Fact]
+		public async Task GenerateHubClient_IgnoresStaticMethods()
+		{
+			var file = await GenerateHubClient(typeof(HubWithStaticMethodTestClass));
+			Assert.DoesNotContain($"public static Task Method();", file);
+		}
+
 		private async Task<string> GenerateHubClient(Type type)
 		{
 			var document = await _generator.GenerateForHubsAsync(new Dictionary<string, Type>

--- a/src/SigSpec.CodeGeneration.CSharp.Tests/TestHubs.cs
+++ b/src/SigSpec.CodeGeneration.CSharp.Tests/TestHubs.cs
@@ -140,6 +140,13 @@ public class HubWithReturnOptionalTestClass : Hub<IClient>
 	}
 }
 
+public class HubWithStaticMethodTestClass : Hub<IClient>
+{
+	public static Task Method()
+	{
+		return Task.CompletedTask;
+	}
+}
 
 public interface IClient
 {

--- a/src/SigSpec.CodeGeneration.TypeScript.Tests/GeneratorTests.cs
+++ b/src/SigSpec.CodeGeneration.TypeScript.Tests/GeneratorTests.cs
@@ -12,12 +12,12 @@ namespace SigSpec.CodeGeneration.TypeScript.Tests
 		private readonly SigSpecToTypeScriptGeneratorSettings _codeGeneratorSettings = new()
 		{
 			TypeScriptGeneratorSettings =
-		{
-			TypeStyle = TypeScriptTypeStyle.Class,
-			NullValue = TypeScriptNullValue.Null,
-			MarkOptionalProperties = false,
-			ConvertConstructorInterfaceData = true
-		}
+			{
+				TypeStyle = TypeScriptTypeStyle.Class,
+				NullValue = TypeScriptNullValue.Null,
+				MarkOptionalProperties = false,
+				ConvertConstructorInterfaceData = true
+			}
 		};
 
 		private readonly SigSpecToTypeScriptGenerator _codeGenerator;
@@ -38,9 +38,9 @@ namespace SigSpec.CodeGeneration.TypeScript.Tests
 		private async Task<string> GenerateHubClient(Type type)
 		{
 			var document = await _generator.GenerateForHubsAsync(new Dictionary<string, Type>
-		{
-			{ "Hub", type }
-		});
+			{
+				{ "Hub", type }
+			});
 			return _codeGenerator.GenerateFile(document);
 		}
 	}

--- a/src/SigSpec.CodeGeneration.TypeScript.Tests/GeneratorTests.cs
+++ b/src/SigSpec.CodeGeneration.TypeScript.Tests/GeneratorTests.cs
@@ -1,0 +1,47 @@
+using NJsonSchema.CodeGeneration.TypeScript;
+using SigSpec.Core;
+using Xunit;
+
+namespace SigSpec.CodeGeneration.TypeScript.Tests
+{
+	public class GeneratorTests
+	{
+		private readonly SigSpecGeneratorSettings _settings = new SigSpecGeneratorSettings();
+		private readonly SigSpecGenerator _generator;
+
+		private readonly SigSpecToTypeScriptGeneratorSettings _codeGeneratorSettings = new()
+		{
+			TypeScriptGeneratorSettings =
+		{
+			TypeStyle = TypeScriptTypeStyle.Class,
+			NullValue = TypeScriptNullValue.Null,
+			MarkOptionalProperties = false,
+			ConvertConstructorInterfaceData = true
+		}
+		};
+
+		private readonly SigSpecToTypeScriptGenerator _codeGenerator;
+
+		public GeneratorTests()
+		{
+			_generator = new SigSpecGenerator(_settings);
+			_codeGenerator = new SigSpecToTypeScriptGenerator(_codeGeneratorSettings);
+		}
+
+		[Fact]
+		public async Task GenerateHubClient_IgnoresStaticMethods()
+		{
+			var file = await GenerateHubClient(typeof(HubWithStaticMethodTestClass));
+			Assert.DoesNotContain($"method(): Promise", file);
+		}
+
+		private async Task<string> GenerateHubClient(Type type)
+		{
+			var document = await _generator.GenerateForHubsAsync(new Dictionary<string, Type>
+		{
+			{ "Hub", type }
+		});
+			return _codeGenerator.GenerateFile(document);
+		}
+	}
+}

--- a/src/SigSpec.CodeGeneration.TypeScript.Tests/TestHubs.cs
+++ b/src/SigSpec.CodeGeneration.TypeScript.Tests/TestHubs.cs
@@ -138,6 +138,13 @@ public class HubWithReturnOptionalTestClass : Hub<IClient>
 	}
 }
 
+public class HubWithStaticMethodTestClass : Hub<IClient>
+{
+	public static Task Method()
+	{
+		return Task.CompletedTask;
+	}
+}
 
 public interface IClient
 {

--- a/src/SigSpec.Core/SigSpecGenerator.cs
+++ b/src/SigSpec.Core/SigSpecGenerator.cs
@@ -76,6 +76,7 @@ namespace SigSpec.Core
             {
                 var returnsChannelReader = m.ReturnType.IsGenericType && m.ReturnType.GetGenericTypeDefinition() == typeof(ChannelReader<>);
                 return
+                    !m.IsStatic &&
                     m.IsPublic &&
                     m.IsSpecialName == false &&
                     m.DeclaringType != typeof(Hub) &&
@@ -92,6 +93,7 @@ namespace SigSpec.Core
             {
                 var returnsChannelReader = m.ReturnType.IsGenericType && m.ReturnType.GetGenericTypeDefinition() == typeof(ChannelReader<>);
                 return
+                    !m.IsStatic &&
                     m.IsPublic &&
                     m.IsSpecialName == false &&
                     m.DeclaringType != typeof(Hub) &&


### PR DESCRIPTION
Stop SigSpec from generating code for static methods.